### PR TITLE
Parser tweaks

### DIFF
--- a/lobsterpy/cli.py
+++ b/lobsterpy/cli.py
@@ -36,8 +36,6 @@ parser.add_argument('--cohpcar', default="COHPCAR.lobster", type=Path,
                     help='path to COHPCAR.lobster. Default is "COHPCAR.lobster". This argument will also be read when COBICARs or COOPCARs are plotted.')
 parser.add_argument('--json', action="store_true",
                     help='will produce a lobsterpy.json with the most important informations')
-parser.add_argument('--filename', default="lobsterpy.json", type=str,
-                    help='path to ICOHPLIST.lobster. Default is "ICOHPLIST.lobster"')
 parser.add_argument('--allbonds', action="store_true", default=False,
                     help='will consider all bonds, not only cation-anion bonds (default) ')
 


### PR DESCRIPTION
I had a quick play with the command-line tools and ran into a few issues. Here are my attempted fixes/improvements. They are atomic commits so should be easy to remove any you disagree with!

- Allow `--poscar` instead of `--POSCAR`, requiring caps is a bit inconvenient and seems inconsistent with the other filename arguments
- `--automaticplot` was raising an error related to a missing (presumably renamed) argument
- The file parsing logic for specific `--plot` modes assumes a specific filename in CWD, I used Pathlib to make it work from another directory
- The `--filename` option doesn't seem to do anything so I removed it.