### PR TITLE
Rework argparse setup: plot/automaticplot/description subcommands

### DIFF
--- a/lobsterpy/cli.py
+++ b/lobsterpy/cli.py
@@ -19,6 +19,7 @@ from pymatgen.electronic_structure.cohp import CompleteCohp
 
 
 def get_parser() -> argparse.ArgumentParser:
+    """Construct argumentparser with subcommands and sections"""
     parser = argparse.ArgumentParser(
         description="Analyze and plot results from Lobster runs."
     )
@@ -140,7 +141,7 @@ def get_parser() -> argparse.ArgumentParser:
         required=True,
         help="Use -h/--help after the chosen subcommand to see further options.",
     )
-    description_parser = subparsers.add_parser(
+    subparsers.add_parser(
         "description",
         parents=[base_parent, auto_parent],
         help=(
@@ -149,7 +150,7 @@ def get_parser() -> argparse.ArgumentParser:
         ),
     )
 
-    autoplot_parser = subparsers.add_parser(
+    subparsers.add_parser(
         "automatic-plot",
         parents=[base_parent, auto_parent, plotting_parent],
         help=(
@@ -203,6 +204,7 @@ def get_parser() -> argparse.ArgumentParser:
         ),
     )
     return parser
+
 
 def _user_figsize(width, height, aspect=None):
     """Get figsize options from user input, if any


### PR DESCRIPTION
I've had a play with the CLI to try and make it a bit easier for users to see what they are allowed to do when.
Does this look reasonable?

Some more argparse features are used to express the relationships
between different arguments. This moves exclusive-argument and
available-argument logic from main() to the parser setup, and should
give more helpful --help pages.

- The subcommands feature allows the three different run-modes to be
  expressed more clearly. Each has its own help page, with only
  relevant arguments.
- "Parent" parsers are mixed to avoid redundancy in setting this up
- Argument groups bring together related arguments, making --help
  easier to navigate.

The downside is that it may not be 100% obvious that users need to
type e.g. `lobsterpy plot -h` to see plot options. I have tried to
explain this in the `lobsterpy -h` page!

This is not completely compatible with the previous syntax, but the
changes are small and motivated:

--plot, --automaticplot, --description keyword arguments have been
replaced by a positional "action" argument which should be set as
"plot", "automatic-plot", or "description".

--plot previously required values to be assigned to it. Now there is a
positional argument when the "plot" action is chosen. So now instead
of e.g.
```
  lobsterpy --poscar /path/to/poscar --plot 1 2 --coop ...
```

we must have
```
  lobsterpy plot 1 2 --poscar /path/to/poscar --coop ...
```

While this arguably is a slight burden on the user, hopefully it will
pay off with easier-to-read command samples. (As we can now always
check the second word to see what mode we are in, which is important
context for other arguments.)