### PR TITLE
Some more argparse usability tweaks: simpler --json and nicer -h

### DIFF
--- a/lobsterpy/cli.py
+++ b/lobsterpy/cli.py
@@ -73,7 +73,7 @@ def get_parser() -> argparse.ArgumentParser:
     plotting_group.add_argument(
         "--ylim",
         dest="ylim",
-        nargs="+",
+        nargs=2,
         default=None,
         type=float,
         help="Energy range for plots",
@@ -81,7 +81,7 @@ def get_parser() -> argparse.ArgumentParser:
     plotting_group.add_argument(
         "--xlim",
         dest="xlim",
-        nargs="+",
+        nargs=2,
         default=None,
         type=float,
         help="COHP/COBI/COOP range for plots",
@@ -110,6 +110,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--saveplot",
         "-s",
         type=str,
+        metavar="FILENAME",
         default=None,
         dest="save_plot",
         help="Save plot to file",
@@ -128,15 +129,12 @@ def get_parser() -> argparse.ArgumentParser:
     auto_group = auto_parent.add_argument_group("Automatic analysis")
     auto_group.add_argument(
         "--json",
-        action="store_true",
-        help="This will produce a lobsterpy.json with the most important information",
-    )
-    auto_group.add_argument(
-        "--filenamejson",
-        "--filename-json",
-        default="lobsterpy.json",
+        nargs="?",
         type=Path,
-        help="Path to json file storing the most important bonding information from the automatic analysis. Default is lobsterpy.json",
+        default=None,
+        metavar="FILENAME",
+        const=Path("lobsterpy.json"),
+        help="Write a JSON file with the most important information",
     )
     auto_group.add_argument(
         "--allbonds",
@@ -270,9 +268,9 @@ def run(args):
         describe = Description(analysis_object=analyse)
         describe.write_description()
 
-        if args.json:
+        if args.json is not None:
             analysedict = analyse.condensed_bonding_analysis
-            with open(args.filenamejson, "w") as fd:
+            with open(args.json, "w") as fd:
                 json.dump(analysedict, fd)
 
     if args.action in ["plot", "automatic-plot"]:

--- a/lobsterpy/test/test_cli.py
+++ b/lobsterpy/test/test_cli.py
@@ -101,7 +101,7 @@ class TestCLI:
 
     def test_json_saved(self, tmp_path, inject_mocks, clean_plot):
         json_path = tmp_path / "data.json"
-        args = ["automatic-plot", "--json", "--filename-json", str(json_path)]
+        args = ["automatic-plot", "--json", str(json_path)]
         test = get_parser().parse_args(args)
         run(test)
         self.assert_is_finite_file(json_path)


### PR DESCRIPTION
- Set nargs=2 for plotting limits. This should make the error message
  slightly less confusing when the wrong number of arguments is
  provided, and makes for much clearer syntax on the help page:

```
[--allbonds] [--ylim YLIM YLIM] [--xlim XLIM XLIM]
```

- Combine `--filename-json` and `--json` args into a single `--json`
  option. The filename can still be provided (`--json FILENAME`), while
  `--json` alone will give the same default as the existing behaviour.
  This can still be distinguished from the default of None (if `--json`
  was not used) so all three cases are covered.

- Use metavar "FILENAME" to make it slightly more obvious on the help
  page how this works. For consistency, this is also used for
  `--save-plot`.

```
[--json [FILENAME]] ... [--save-plot FILENAME]
```