### PR TITLE
Bonding antibonding

### DIFF
--- a/lobsterpy/TestData/cli-reference.json
+++ b/lobsterpy/TestData/cli-reference.json
@@ -1640,7 +1640,7 @@
                 ]
             ]
         },
-        "stdout": "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.\n"
+        "stdout": "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.\n"
     },
     "automatic-plot --style ggplot": {
         "plot": {
@@ -3283,7 +3283,7 @@
                 ]
             ]
         },
-        "stdout": "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.\n"
+        "stdout": "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.\n"
     },
     "automaticplot --allbonds": {
         "plot": {
@@ -4926,15 +4926,15 @@
                 ]
             ]
         },
-        "stdout": "The compound NaCl has 2 symmetry-independent atoms(s) with relevant bonds: Na1, Cl2.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.\nCl2 has an octahedral (CN=6) coordination environment. It has 6 Cl-Na (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.\n"
+        "stdout": "The compound NaCl has 2 symmetry-independent atoms(s) with relevant bonds: Na1, Cl2.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.\nCl2 has an octahedral (CN=6) coordination environment. It has 6 Cl-Na (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.\n"
     },
     "description": {
         "plot": null,
-        "stdout": "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.\n"
+        "stdout": "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.\n"
     },
     "description --all-bonds": {
         "plot": null,
-        "stdout": "The compound NaCl has 2 symmetry-independent atoms(s) with relevant bonds: Na1, Cl2.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.\nCl2 has an octahedral (CN=6) coordination environment. It has 6 Cl-Na (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.\n"
+        "stdout": "The compound NaCl has 2 symmetry-independent atoms(s) with relevant bonds: Na1, Cl2.\nNa1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.\nCl2 has an octahedral (CN=6) coordination environment. It has 6 Cl-Na (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.\n"
     },
     "plot --summed 1 2": {
         "plot": {

--- a/lobsterpy/cohp/describe.py
+++ b/lobsterpy/cohp/describe.py
@@ -82,7 +82,9 @@ class Description:
                             + " (mean ICOHP: "
                             ""
                             + properties["ICOHP_mean"]
-                            + " eV," + str(round(properties["antibonding"]["perc"]*100,3)) + " percent antibonding interaction below EFermi)"
+                            + " eV,"
+                            + str(round(properties["antibonding"]["perc"] * 100, 3))
+                            + " percent antibonding interaction below EFermi)"
                         )
 
                 if len(bond_info) > 1:
@@ -155,7 +157,9 @@ class Description:
                             + " (mean ICOHP: "
                             ""
                             + properties["ICOHP_mean"]
-                            + " eV," + str(round(properties["antibonding"]["perc"]*100,3)) + " percent antibonding interaction below EFermi)"
+                            + " eV,"
+                            + str(round(properties["antibonding"]["perc"] * 100, 3))
+                            + " percent antibonding interaction below EFermi)"
                         )
 
                 if len(bond_info) > 1:

--- a/lobsterpy/cohp/describe.py
+++ b/lobsterpy/cohp/describe.py
@@ -82,7 +82,7 @@ class Description:
                             + " (mean ICOHP: "
                             ""
                             + properties["ICOHP_mean"]
-                            + " eV, antibonding interaction below EFermi)"
+                            + " eV," + str(round(properties["antibonding"]["perc"]*100,3)) + " percent antibonding interaction below EFermi)"
                         )
 
                 if len(bond_info) > 1:
@@ -155,7 +155,7 @@ class Description:
                             + " (mean ICOHP: "
                             ""
                             + properties["ICOHP_mean"]
-                            + " eV, antibonding interaction below EFermi)"
+                            + " eV," + str(round(properties["antibonding"]["perc"]*100,3)) + " percent antibonding interaction below EFermi)"
                         )
 
                 if len(bond_info) > 1:

--- a/lobsterpy/cohp/test/test_describe.py
+++ b/lobsterpy/cohp/test/test_describe.py
@@ -256,21 +256,21 @@ class TestDescribe(unittest.TestCase):
             self.describe_CdF.text,
             [
                 "The compound CdF2 has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Cd1.",
-                "Cd1 has a cubic (CN=8) coordination environment. It has 8 Cd-F (mean ICOHP: -0.62 eV, antibonding interaction below EFermi) bonds.",
+                "Cd1 has a cubic (CN=8) coordination environment. It has 8 Cd-F (mean ICOHP: -0.62 eV,44.218 percent antibonding interaction below EFermi) bonds.",
             ],
         )
         self.assertEqual(
             self.describe_NaCl.text,
             [
                 "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.",
-                "Na1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.",
+                "Na1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.",
             ],
         )
         self.assertEqual(
             self.describe_NaCl.text,
             [
                 "The compound NaCl has 1 symmetry-independent cation(s) with relevant cation-anion interactions: Na1.",
-                "Na1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV, antibonding interaction below EFermi) bonds.",
+                "Na1 has an octahedral (CN=6) coordination environment. It has 6 Na-Cl (mean ICOHP: -0.57 eV,4.866 percent antibonding interaction below EFermi) bonds.",
             ],
         )
 


### PR DESCRIPTION
- Have included antibonding and bonding integral and percentage values in summary dict
- Removed hardcoded dependence on start energy range, now it will directly consider the lowest energy range as set using `COHPstartEnergy` 
- Main changes are in the function of` _integrate_antbdstates_below_efermi(),_integrate_antbdstates_below_efermi_for_set_cohps() `and functions within
- added a warning mentioning the limitations of integral and percentage values 
- Updated `describe.py` to now show antibonding percentage below fermi level
