### PR TITLE
Fix docs build fails

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinx-argparse==0.3.1
 sphinx-pdj-theme==0.2.1
 m2r2==0.3.2
 myst-parser==0.17.2
-docutils==0.18.1
+docutils
 numpy==1.22.3
 matplotlib==3.5.1
 matplotlib-inline==0.1.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,4 @@ docutils
 numpy==1.22.3
 matplotlib==3.5.1
 matplotlib-inline==0.1.3
-pymatgen
+pymatgen==2022.4.26

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,4 @@ docutils
 numpy==1.22.3
 matplotlib==3.5.1
 matplotlib-inline==0.1.3
-pymatgen==2022.4.26
+pymatgen

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,4 @@ docutils
 numpy==1.22.3
 matplotlib==3.5.1
 matplotlib-inline==0.1.3
-pymatgen==2022.4.26
+pymatgen==2022.5.19


### PR DESCRIPTION
-  Fixed the docs building failing issue.
The problem was with conflicting `docutils==0.18.1`. As Sphinx 4.5.0 requires docutils<0.18.1.

I confirmed making the changes on read the docs and it ran successfully

