### PR TITLE
run no_implicit_optional on lobsterpy/plotting/__init__.py

### DIFF
--- a/lobsterpy/plotting/__init__.py
+++ b/lobsterpy/plotting/__init__.py
@@ -53,13 +53,13 @@ class PlainCohpPlotter(CohpPlotter):
 
     def get_plot(
         self,
-        ax: matplotlib.axes.Axes = None,
-        xlim: Tuple[float, float] = None,
-        ylim: Tuple[float, float] = None,
-        plot_negative: bool = None,
+        ax: Optional[matplotlib.axes.Axes] = None,
+        xlim: Optional[Tuple[float, float]] = None,
+        ylim: Optional[Tuple[float, float]] = None,
+        plot_negative: Optional[bool] = None,
         integrated: bool = False,
         invert_axes: bool = True,
-        sigma: float = None,
+        sigma: Optional[float] = None,
     ):
         """
         Get a matplotlib plot showing the COHP.


### PR DESCRIPTION
Short demo test using `no_implicit_optional` code on problematic 'lobsterpy/plotting/__init__.py' file. If does not work will try to do it manually. 