### PR TITLE
Fix KeyError in issue in cation-anion mode

### DIFF
--- a/lobsterpy/cohp/analyze.py
+++ b/lobsterpy/cohp/analyze.py
@@ -583,14 +583,14 @@ class Analysis:
                 elif b == nameion:
                     key_here = a
 
-            if large_antbd_dict is None:
+            if large_antbd_dict is None and small_antbd_dict:
                 bond_dict[key_here] = {
                     "ICOHP_mean": str(round(np.mean(item), 2)),
                     "ICOHP_sum": str(round(np.sum(item), 2)),
                     "has_antibdg_states_below_Efermi": small_antbd_dict[key],
                     "number_of_bonds": len(item),
                 }
-            else:
+            if large_antbd_dict is not None:
                 bond_dict[key_here] = {
                     "ICOHP_mean": str(round(np.mean(item), 2)),
                     "ICOHP_sum": str(round(np.sum(item), 2)),


### PR DESCRIPTION
## Issue description

- LobsterPy automatic analysis failed for compounds in cation-anion mode with KeyError

## Reason

- LobsterNeighbours method from chemenv returned lables as none for anion-cation bonds detected due to additional condition we set to 1 as we are only interested in cation-anion bonds
- Anaylsis module already does check if labels are none  in `def _get_antibdg_states`
- However, the  for None Lables cases an empty dictionary is returned, thus leading to errors in automatic analysis

## Proposed solution and changes in code

- Included additional check-in [Line 586](https://github.com/naik-aakash/LobsterPy/blob/10f591f885e768ac555aee8ae86a2d5ebd2c6484/lobsterpy/cohp/analyze.py#L586) to check if antibdg dict is empty (`def _get_bond_dict`)
- Changed else condition of [Line 593](https://github.com/naik-aakash/LobsterPy/blob/10f591f885e768ac555aee8ae86a2d5ebd2c6484/lobsterpy/cohp/analyze.py#L593) 