### PR TITLE
Fix missing matplotlib style file in package installation 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest pytest-mock pytest-split pytest-cov
         python -m pip install types-setuptools
-        pip install -e .[featurizer]
+        pip install .[featurizer]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
      "typing",
 ]
 
+[tool.setuptools.package-data]
+"lobsterpy.plotting" = ["lobsterpy_base.mplstyle"]
+
 [project.urls]
 homepage = "https://lobsterpy.readthedocs.io/en/latest/?badge=latest"
 repository = "https://github.com/JaGeo/LobsterPy"


### PR DESCRIPTION
1) Added the missing setup tools line which now includes the matplotlib style file necessary for plotting
2) Updated testing workflow to make static install and avoid such bugs in future

Closes #158 