### PR TITLE
Add Contributing guide to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ It is also possible to start this automatic analysis from a Python script. See "
 ## Comprehensive documentation
 * Checkout the [documentation and tutorials](https://jageo.github.io/LobsterPy/) for more details.
 
+## Contributing
+A short guide to contributing to lobsterpy can be found [here](https://jageo.github.io/LobsterPy/dev/contributing.html)
+Additional information for developers can be found [here](https://jageo.github.io/LobsterPy/dev/dev_installation.html).
+
 ## How to cite?
 Please cite our paper: J. George, G. Petretto, A. Naik, M. Esters, A. J. Jackson, R. Nelson, R. Dronskowski, G.-M. Rignanese, G. Hautier, **ChemPlusChem**, [https://doi.org/10.1002/cplu.202200123](https://doi.org/10.1002/cplu.202200123).
 Please cite [pymatgen](https://github.com/materialsproject/pymatgen), [Lobster](https://www.cohp.de), and [ChemEnv](https://doi.org/10.1107/S2052520620007994) correctly as well.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ It is also possible to start this automatic analysis from a Python script. See "
 * Checkout the [documentation and tutorials](https://jageo.github.io/LobsterPy/) for more details.
 
 ## Contributing
-A short guide to contributing to lobsterpy can be found [here](https://jageo.github.io/LobsterPy/dev/contributing.html)
+A short guide to contributing to lobsterpy can be found [here](https://jageo.github.io/LobsterPy/dev/contributing.html).
 Additional information for developers can be found [here](https://jageo.github.io/LobsterPy/dev/dev_installation.html).
 
 ## How to cite?

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@ reference/cli
 ```{toctree}
 :caption: Contributing Guide
 :hidden:
-dev/dev_installation
 dev/contributing
+dev/dev_installation
 ```
 
 ```{toctree}


### PR DESCRIPTION
Closes #223 

# Changes

1. Add contributing guide/developer installation guide to readme
2. Reorder doc index  from` developer installation- contributing guide` to `contributing guide-developer installation`