### PR TITLE
tutorial: replace os with pathlib.Path

### DIFF
--- a/docs/tutorial/tutorial.ipynb
+++ b/docs/tutorial/tutorial.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "```python\n",
     "#### Change directory to your Lobster computations (Change this cell block type to Code and remove formatting when executing locally)\n",
-    "directory = \"Lobsterpy/tests/test_data/CdF_comp_range/\"\n",
+    "directory = Path(\"LobsterPy\") / \"tests\" / \"test_data\" / \"CdF_comp_range\"\n",
     "```"
    ]
   },
@@ -335,7 +335,7 @@
    "outputs": [],
    "source": [
     "# Directory to your VASP and Lobster computations\n",
-    "directory = Path(\".\") / \"..\" / \"..\" / \"tests\" / \"test_data\" / \"K3Sb\"\n"
+    "directory = Path(\".\") / \"..\" / \"..\" / \"tests\" / \"test_data\" / \"K3Sb\""
    ]
   },
   {
@@ -345,7 +345,7 @@
    "source": [
     "```python\n",
     "#### Change directory to your Lobster computations (Change this cell block type to Code and remove formatting when executing locally)\n",
-    "directory = \"LobsterPy/tests/test_data/K3Sb/\"\n",
+    "directory = Path(\"LobsterPy\") / \"tests\" / \"test_data\" / \"K3Sb\"\n",
     "```"
    ]
   },
@@ -532,16 +532,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8d9b378-0822-43e3-9e04-77bd25f5f3e6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "directory = Path(\".\") / \"..\" / \"..\" / \"tests\" / \"test_data\" / \"NaCl_comp_range\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "b3a9758b",
    "metadata": {
     "tags": [
@@ -551,6 +541,7 @@
    "outputs": [],
    "source": [
     "# Load Lobster DOS\n",
+    "directory = Path(\".\") / \"..\" / \"..\" / \"tests\" / \"test_data\" / \"NaCl_comp_range\"\n",
     "dos = Doscar(doscar=directory / 'DOSCAR.lobster.gz',\n",
     "             structure_file=directory / 'POSCAR.gz')"
    ]
@@ -562,6 +553,7 @@
    "source": [
     "```python\n",
     "# Load Lobster DOS (Change this cell block type to Code when executing locally)\n",
+    "directory = Path(\"LobsterPy\") / \"tests\" / \"test_data\" / \"NaCl_comp_range\"\n",
     "dos = Doscar(doscar=directory / 'DOSCAR.lobster.gz',\n",
     "             structure_file=directory / 'POSCAR.gz')\n",
     "```"

--- a/docs/tutorial/tutorial.ipynb
+++ b/docs/tutorial/tutorial.ipynb
@@ -50,7 +50,7 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
+    "from pathlib import Path\n",
     "from lobsterpy.cohp.analyze import Analysis\n",
     "from lobsterpy.cohp.describe import Description\n",
     "import warnings\n",
@@ -69,7 +69,7 @@
    "outputs": [],
    "source": [
     "# Directory of your VASP and Lobster computations\n",
-    "directory = \"../../tests/test_data/CdF_comp_range/\""
+    "directory = Path(\".\") / \"..\" / \"..\" / \"tests\" / \"test_data\" / \"CdF_comp_range\""
    ]
   },
   {
@@ -92,10 +92,10 @@
    "source": [
     "# Initialize Analysis object\n",
     "analyse = Analysis(\n",
-    "    path_to_poscar=os.path.join(directory, \"POSCAR.gz\"),\n",
-    "    path_to_icohplist=os.path.join(directory, \"ICOHPLIST.lobster.gz\"),\n",
-    "    path_to_cohpcar=os.path.join(directory, \"COHPCAR.lobster.gz\"),\n",
-    "    path_to_charge=os.path.join(directory, \"CHARGE.lobster.gz\"),\n",
+    "    path_to_poscar=directory / \"POSCAR.gz\",\n",
+    "    path_to_icohplist=directory / \"ICOHPLIST.lobster.gz\",\n",
+    "    path_to_cohpcar=directory / \"COHPCAR.lobster.gz\",\n",
+    "    path_to_charge=directory / \"CHARGE.lobster.gz\",\n",
     "    which_bonds=\"cation-anion\",\n",
     ")"
    ]
@@ -195,10 +195,10 @@
     "\n",
     "```python\n",
     "analyse = Analysis(\n",
-    "    path_to_poscar=os.path.join(directory, \"POSCAR.gz\"),\n",
-    "    path_to_icohplist=os.path.join(directory, \"ICOBILIST.lobster.gz\"),\n",
-    "    path_to_cohpcar=os.path.join(directory, \"COBICAR.lobster.gz\"),\n",
-    "    path_to_charge=os.path.join(directory, \"CHARGE.lobster.gz\"),\n",
+    "    path_to_poscar=directory / \"POSCAR.gz\",\n",
+    "    path_to_icohplist=directory / \"ICOHPLIST.lobster.gz\",\n",
+    "    path_to_cohpcar=directory / \"COHPCAR.lobster.gz\",\n",
+    "    path_to_charge=directory / \"CHARGE.lobster.gz\",\n",
     "    which_bonds=\"cation-anion\",\n",
     "    are_cobis=True,\n",
     "    noise_cutoff=0.001,\n",
@@ -232,10 +232,10 @@
    "outputs": [],
    "source": [
     "analyse = Analysis(\n",
-    "    path_to_poscar=os.path.join(directory, \"POSCAR.gz\"),\n",
-    "    path_to_icohplist=os.path.join(directory, \"ICOHPLIST.lobster.gz\"),\n",
-    "    path_to_cohpcar=os.path.join(directory, \"COHPCAR.lobster.gz\"),\n",
-    "    path_to_charge=os.path.join(directory, \"CHARGE.lobster.gz\"),\n",
+    "    path_to_poscar=directory / \"POSCAR.gz\",\n",
+    "    path_to_icohplist=directory / \"ICOHPLIST.lobster.gz\",\n",
+    "    path_to_cohpcar=directory / \"COHPCAR.lobster.gz\",\n",
+    "    path_to_charge=directory / \"CHARGE.lobster.gz\",\n",
     "    which_bonds=\"cation-anion\",\n",
     "    orbital_resolved=True,\n",
     "    orbital_cutoff=0.03,\n",
@@ -335,7 +335,7 @@
    "outputs": [],
    "source": [
     "# Directory to your VASP and Lobster computations\n",
-    "directory = \"../../tests/test_data/K3Sb/\""
+    "directory = Path(\".\") / \"..\" / \"..\" / \"tests\" / \"test_data\" / \"K3Sb\"\n"
    ]
   },
   {
@@ -358,17 +358,17 @@
    "source": [
     "# Get calculation quality summary dict\n",
     "calc_quality_K3Sb = Analysis.get_lobster_calc_quality_summary(\n",
-    "            path_to_poscar=os.path.join(directory, \"POSCAR.gz\"),\n",
-    "            path_to_charge=os.path.join(directory, \"CHARGE.lobster.gz\"),\n",
-    "            path_to_lobsterin=os.path.join(directory,\"lobsterin.gz\"),\n",
-    "            path_to_lobsterout=os.path.join(directory,\"lobsterout.gz\"),\n",
+    "            path_to_poscar=directory / \"POSCAR.gz\",\n",
+    "            path_to_charge=directory / \"CHARGE.lobster.gz\",\n",
+    "            path_to_lobsterin=directory / \"lobsterin.gz\",\n",
+    "            path_to_lobsterout=directory / \"lobsterout.gz\",\n",
     "            potcar_symbols=[\"K_sv\", \"Sb\"], # if POTCAR exists, then provide path_to_potcar and set this to None \n",
-    "            path_to_bandoverlaps=os.path.join(directory,\"bandOverlaps.lobster.gz\"),\n",
+    "            path_to_bandoverlaps=directory / \"bandOverlaps.lobster.gz\",\n",
     "            dos_comparison=True, # set to false to disable DOS comparisons \n",
     "            bva_comp=True, # set to false to disable LOBSTER charge classification comparisons with BVA method\n",
-    "            path_to_doscar=os.path.join(directory,\"DOSCAR.LSO.lobster.gz\"),\n",
+    "            path_to_doscar=directory / \"DOSCAR.LSO.lobster.gz\",\n",
     "            e_range=[-20, 0],\n",
-    "            path_to_vasprun=os.path.join(directory,\"vasprun.xml.gz\"),\n",
+    "            path_to_vasprun=directory / \"vasprun.xml.gz\",\n",
     "            n_bins=256,\n",
     "        )\n",
     "calc_quality_K3Sb"
@@ -532,6 +532,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f8d9b378-0822-43e3-9e04-77bd25f5f3e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "directory = Path(\".\") / \"..\" / \"..\" / \"tests\" / \"test_data\" / \"NaCl_comp_range\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "b3a9758b",
    "metadata": {
     "tags": [
@@ -541,8 +551,8 @@
    "outputs": [],
    "source": [
     "# Load Lobster DOS\n",
-    "dos = Doscar(doscar='../../tests/test_data/NaCl_comp_range/DOSCAR.lobster.gz',\n",
-    "            structure_file='../../tests/test_data/NaCl_comp_range/POSCAR.gz')"
+    "dos = Doscar(doscar=directory / 'DOSCAR.lobster.gz',\n",
+    "             structure_file=directory / 'POSCAR.gz')"
    ]
   },
   {
@@ -552,8 +562,8 @@
    "source": [
     "```python\n",
     "# Load Lobster DOS (Change this cell block type to Code when executing locally)\n",
-    "dos = Doscar(doscar='LobsterPy/tests/test_data/NaCl_comp_range/DOSCAR.lobster.gz',\n",
-    "            structure_file='LobsterPy/tests/test_data/NaCl_comp_range/POSCAR.gz')\n",
+    "dos = Doscar(doscar=directory / 'DOSCAR.lobster.gz',\n",
+    "             structure_file=directory / 'POSCAR.gz')\n",
     "```"
    ]
   },
@@ -642,14 +652,14 @@
    "outputs": [],
    "source": [
     "graph_NaCl_all = LobsterGraph(\n",
-    "    path_to_poscar=\"../../tests/test_data/NaCl_comp_range/POSCAR.gz\",\n",
-    "    path_to_charge=\"../../tests/test_data/NaCl_comp_range/CHARGE.lobster.gz\",\n",
-    "    path_to_cohpcar=\"../../tests/test_data/NaCl_comp_range/COHPCAR.lobster.gz\",\n",
-    "    path_to_icohplist=\"../../tests/test_data/NaCl_comp_range/ICOHPLIST.lobster.gz\",\n",
+    "    path_to_poscar=directory / \"POSCAR.gz\",\n",
+    "    path_to_charge=directory / \"CHARGE.lobster.gz\",\n",
+    "    path_to_cohpcar=directory / \"COHPCAR.lobster.gz\",\n",
+    "    path_to_icohplist=directory / \"ICOHPLIST.lobster.gz\",\n",
     "    add_additional_data_sg=True,\n",
-    "    path_to_icooplist=\"../../tests/test_data/NaCl_comp_range/ICOOPLIST.lobster.gz\",\n",
-    "    path_to_icobilist=\"../../tests/test_data/NaCl_comp_range/ICOBILIST.lobster.gz\",\n",
-    "    path_to_madelung=\"../../tests/test_data/NaCl_comp_range/MadelungEnergies.lobster.gz\",\n",
+    "    path_to_icooplist=directory / \"ICOOPLIST.lobster.gz\",\n",
+    "    path_to_icobilist=directory / \"ICOBILIST.lobster.gz\",\n",
+    "    path_to_madelung=directory / \"MadelungEnergies.lobster.gz\",\n",
     "    which_bonds=\"all\",\n",
     "    start=None,\n",
     ")"
@@ -663,14 +673,14 @@
     "```python\n",
     "#### (Change this cell block type to Code or copy it from here when executing locally)\n",
     "graph_NaCl_all = LobsterGraph(\n",
-    "    path_to_poscar=\"LobsterPy/tests/test_data/NaCl_comp_range/POSCAR.gz\",\n",
-    "    path_to_charge=\"LobsterPy/tests/test_data/NaCl_comp_range/CHARGE.lobster.gz\",\n",
-    "    path_to_cohpcar=\"LobsterPy/tests/test_data/NaCl_comp_range/COHPCAR.lobster.gz\",\n",
-    "    path_to_icohplist=\"LobsterPy/tests/test_data/NaCl_comp_range/ICOHPLIST.lobster.gz\",\n",
+    "    path_to_poscar=directory / \"POSCAR.gz\",\n",
+    "    path_to_charge=directory / \"CHARGE.lobster.gz\",\n",
+    "    path_to_cohpcar=directory / \"COHPCAR.lobster.gz\",\n",
+    "    path_to_icohplist=directory / \"ICOHPLIST.lobster.gz\",\n",
     "    add_additional_data_sg=True,\n",
-    "    path_to_icooplist=\"LobsterPy/tests/test_data/NaCl_comp_range/ICOOPLIST.lobster.gz\",\n",
-    "    path_to_icobilist=\"LobsterPy/tests/test_data/NaCl_comp_range/ICOBILIST.lobster.gz\",\n",
-    "    path_to_madelung=\"LobsterPy/tests/test_data/NaCl_comp_range/MadelungEnergies.lobster.gz\",\n",
+    "    path_to_icooplist=directory / \"ICOOPLIST.lobster.gz\",\n",
+    "    path_to_icobilist=directory / \"ICOBILIST.lobster.gz\",\n",
+    "    path_to_madelung=directory / \"MadelungEnergies.lobster.gz\",\n",
     "    which_bonds=\"all\",\n",
     "    start=None,\n",
     ")\n",
@@ -765,7 +775,7 @@
    "source": [
     "# Initialize the batch COXX featurizer \n",
     "fp_cohp_bonding = BatchCoxxFingerprint(\n",
-    "            path_to_lobster_calcs=\"../../tests/test_data/Featurizer_test_data/Lobster_calcs\",\n",
+    "            path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\",\n",
     "            e_range=[-15, 0], \n",
     "            feature_type=\"bonding\",\n",
     "            normalize=True, # affects only the fingerprint similarity matrix computation\n",
@@ -783,7 +793,7 @@
     "```python\n",
     "## Initialize batch COXX featurizer (Change this cell block type to Code and remove formatting when executing locally)\n",
     "fp_cohp_bonding = BatchCoxxFingerprint(\n",
-    "    path_to_lobster_calcs=\"LobsterPy/tests/test_data/Featurizer_test_data/Lobster_calcs\",\n",
+    "    path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\",\n",
     "    e_range=[-15, 0], \n",
     "    feature_type=\"bonding\",\n",
     "    normalize=True, # affects only the fingerprint similarity matrix computation\n",
@@ -850,7 +860,7 @@
    "outputs": [],
    "source": [
     "# Initialize the batch DOS featurizer\n",
-    "batch_dos = BatchDosFeaturizer(path_to_lobster_calcs='../../tests/test_data/Featurizer_test_data/Lobster_calcs/', # path to parent lobster calcs\n",
+    "batch_dos = BatchDosFeaturizer(path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\", # path to parent lobster calcs\n",
     "            use_lso_dos=True, # will enforce using DOSCAR.LSO.lobster\n",
     "            add_element_dos_moments=True, # set to false to not have element moments dos features \n",
     "            e_range=None, # setting this to none results in features computed for the entire energy range \n",
@@ -866,7 +876,7 @@
    "source": [
     "```python\n",
     "## Initialize batch DOS featurizer (Change this cell block type to Code and remove formatting when executing locally)\n",
-    "batch_dos = BatchDosFeaturizer(path_to_lobster_calcs='LobsterPy/tests/test_data/Featurizer_test_data/Lobster_calcs/', # path to parent lobster calcs\n",
+    "batch_dos = BatchDosFeaturizer(path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\", # path to parent lobster calcs\n",
     "            use_lso_dos=True, # will enforce using DOSCAR.LSO.lobster\n",
     "            add_element_dos_moments=True, # set to false to not have element moments dos features \n",
     "            e_range=None, # setting this to none results in features computed for the entire energy range \n",
@@ -932,7 +942,7 @@
    "source": [
     "# Initialize batch summary featurizer\n",
     "summary_features = BatchSummaryFeaturizer(\n",
-    "            path_to_lobster_calcs=\"../../tests/test_data/Featurizer_test_data/Lobster_calcs\",\n",
+    "            path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\",\n",
     "            bonds=\"all\",\n",
     "            include_cobi_data=False,\n",
     "            include_coop_data=False,\n",
@@ -951,7 +961,7 @@
     "```python\n",
     "## Initialize batch summary featurizer (Change this cell block type to Code and remove formatting when executing locally)\n",
     "summary_features = BatchSummaryFeaturizer(\n",
-    "            path_to_lobster_calcs=\"LobsterPy/tests/test_data/Featurizer_test_data/Lobster_calcs\",\n",
+    "            path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\",\n",
     "            bonds=\"all\",\n",
     "            include_cobi_data=False,\n",
     "            include_coop_data=False,\n",
@@ -999,7 +1009,7 @@
    },
    "outputs": [],
    "source": [
-    "batch_sg = BatchStructureGraphs(path_to_lobster_calcs='../../tests/test_data/Featurizer_test_data/Lobster_calcs/',\n",
+    "batch_sg = BatchStructureGraphs(path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\",\n",
     "                                add_additional_data_sg=True,\n",
     "                                which_bonds='all',\n",
     "                                n_jobs=3,\n",
@@ -1013,7 +1023,7 @@
    "source": [
     "```python\n",
     "## Initialize batch structure graphs featurizer (Change this cell block type to Code and remove formatting when executing locally)\n",
-    "batch_sg = BatchStructureGraphs(path_to_lobster_calcs='LobsterPy/tests/test_data/Featurizer_test_data/Lobster_calcs/',\n",
+    "batch_sg = BatchStructureGraphs(path_to_lobster_calcs=directory / \"..\" / \"Featurizer_test_data\" / \"Lobster_calcs\",\n",
     "                                add_additional_data_sg=True,\n",
     "                                which_bonds='all',\n",
     "                                n_jobs=3,\n",

--- a/docs/tutorial/tutorial.ipynb
+++ b/docs/tutorial/tutorial.ipynb
@@ -18,7 +18,7 @@
     "```bash\n",
     "git clone --filter=blob:none --no-checkout https://github.com/JaGeo/LobsterPy.git\n",
     "cd LobsterPy\n",
-    "git sparse-checkout set tests/test_data/*\n",
+    "git sparse-checkout set tests/test_data\n",
     "git read-tree -mu HEAD\n",
     "```"
    ]


### PR DESCRIPTION
Part of https://github.com/openjournals/joss-reviews/issues/6286.

This also fixes an issue I had with the git sparse checkout command.

Some questions:
- Is there a need for a sparse checkout?  Is the rest of the code history ~large relative to the test data?  In my full clone there was basically no time or size difference, and a regular clone would be less confusing for beginners.
- When looking at the notebook in the rendered documentation there are cells that are missing compared to when running in Jupyter, specifically those that set `directory`.  Does anyone know why this is?  I was thinking that there were duplicate cells (one code and one markdown for each directory setting), and I was hoping to get rid of them, but if they don't show in the built docs...