### PR TITLE
Update readme

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-mock pytest-split pytest-cov pytestify
+        python -m pip install flake8 pytest pytest-mock pytest-split pytest-cov
         python -m pip install types-setuptools
         pip install .[featurizer]
     - name: Test with pytest and coverage

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Install using ``pip install lobsterpy``
 ### Installation with featurizer
 Install using ``pip install lobsterpy[featurizer]``
 
+### Contributing guidelines / Developers installation
+A short guide to contributing to LobsterPy can be found [here](https://jageo.github.io/LobsterPy/dev/contributing.html).
+Additional information for developers can be found [here](https://jageo.github.io/LobsterPy/dev/dev_installation.html).
+
 
 ## Basic usage
 
@@ -77,9 +81,6 @@ It is also possible to start this automatic analysis from a Python script. See "
 ## Comprehensive documentation
 * Checkout the [documentation and tutorials](https://jageo.github.io/LobsterPy/) for more details.
 
-## Contributing
-A short guide to contributing to LobsterPy can be found [here](https://jageo.github.io/LobsterPy/dev/contributing.html).
-Additional information for developers can be found [here](https://jageo.github.io/LobsterPy/dev/dev_installation.html).
 
 ## How to cite?
 Please cite our paper: A. A. Naik, K. Ueltzen, C. Ertural, A. J. Jackson, J. George, *Journal of Open Source Software* **2024**, *9*, 6286. [https://joss.theoj.org/papers/10.21105/joss.06286](https://joss.theoj.org/papers/10.21105/joss.06286).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ changelog = "https://jageo.github.io/LobsterPy/about/changelog.html"
 [project.optional-dependencies]
 featurizer = ["mendeleev==0.17.0"]
 dev = ["pre-commit>=2.12.1"]
-tests = ["flake8", "pytest", "pytest-mock", "pytest-split", "pytest-cov"]
+tests = ["flake8", "pytest", "pytest-mock", "pytest-split", "pytest-cov", "types-setuptools"]
 docs = [
     "sphinx-copybutton==0.5.2",
     "sphinx>=5,<8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.9,<3.13"
 dependencies = [
      "pymatgen>=2024.5.1",
-     "numpy==1.26",
+     "numpy<2.0.0",
      "typing",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 requires-python = ">=3.9,<3.13"
 dependencies = [
      "pymatgen>=2024.5.1",
-     "numpy",
+     "numpy==1.26",
      "typing",
 ]
 


### PR DESCRIPTION
Closes #295  and #301

# Changes

1.  Consistent CI and package dependencies
2. Removed redundant pytestify from ci
3. Restructure readme > move dev installation below normal installation
4. Pin numpy to `numpy==1.26`