### PR TITLE
Explicitly use `agg` backend to avoid OS inconsistency

### DIFF
--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,6 +9,7 @@ import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.style
 import numpy as np
@@ -71,6 +72,9 @@ class TestCLI:
 
     @pytest.mark.parametrize("args", test_cases)
     def test_cli_results(self, args, capsys, inject_mocks, clean_plot):
+        # Use Ubuntu default backend for consistency across OS
+        mpl.use("agg")
+
         test = get_parser().parse_args(args)
         run(test)
 


### PR DESCRIPTION
### Summary
- Explicitly use `agg` backend (the default for Ubuntu) to avoid OS inconsistency ([the default backend for MacOS is `MacOSX`](https://matplotlib.org/stable/users/explain/figure/backends.html)), to fix #297.

- No other test fail on MacOS:
  ```
  (venv) yang@Yang-MacBook LobsterPy % pytest tests --maxfail 1000
  .........................................s............................................................................ [ 87%]
  .................                                                                                                      [100%]
  ==================================================== slowest 30 durations ====================================================
  22.51s setup    tests/cohp/test_describe.py::TestDescribe::test_text
  20.81s call     tests/featurize/test_batch.py::TestExceptions::test_batch_summary_featurizer_exception
  14.95s call     tests/featurize/test_batch.py::TestBatchSummaryFeaturizer::test_summary_featurize_with_json_overall
  11.97s call     tests/featurize/test_batch.py::TestBatchSummaryFeaturizer::test_summary_featurize_orbitalwise
  11.63s call     tests/featurize/test_batch.py::TestBatchSummaryFeaturizer::test_summary_featurize_without_json
  8.56s call     tests/cli/test_cli.py::TestCLI::test_cli_interactive_plotter_coops
  8.39s setup    tests/cohp/test_analyze.py::TestAnalyse::test_all_attributes_nacl_pymatgen_objs
  8.31s call     tests/featurize/test_batch.py::TestBatchSummaryFeaturizer::test_summary_featurize_with_json
  8.21s call     tests/featurize/test_batch.py::TestBatchSummaryFeaturizer::test_summary_featurize_with_json_antibonding
  8.16s call     tests/featurize/test_batch.py::TestBatchSummaryFeaturizer::test_summary_featurize_with_json_bonding
  8.13s setup    tests/cohp/test_analyze.py::TestAnalyse::test_all_attributes_cdf_comp_range_coop
  6.79s call     tests/featurize/test_batch.py::TestBatchSummaryFeaturizer::test_summary_featurize_with_no_bonds
  5.96s call     tests/cohp/test_describe.py::TestCalcQualityDescribeWarnings::test_warnings
  5.26s call     tests/featurize/test_batch.py::TestBatchStructureGraphs::test_batch_structure_graphs_cation_anion_bonds
  5.07s call     tests/featurize/test_batch.py::TestBatchStructureGraphs::test_batch_structure_graphs_all_bonds
  4.96s call     tests/featurize/test_batch.py::TestBatchCoxxFingerprint::test_fp_cohp_overall
  4.94s call     tests/featurize/test_batch.py::TestBatchCoxxFingerprint::test_fp_cohp_bonding
  4.92s call     tests/featurize/test_batch.py::TestBatchCoxxFingerprint::test_fp_cobi
  4.83s call     tests/featurize/test_batch.py::TestBatchCoxxFingerprint::test_fp_coop
  4.29s setup    tests/cohp/test_describe.py::TestDescribe::test_write_description
  3.42s call     tests/featurize/test_batch.py::TestBatchDosFeaturizer::test_batch_dos_featurizer_lso
  3.36s call     tests/featurize/test_core.py::TestFeaturizeLobsterpy::test_featurize_mp463
  3.36s call     tests/featurize/test_batch.py::TestBatchDosFeaturizer::test_batch_dos_featurizer_non_lso
  3.07s call     tests/plotting/test_plotting.py::TestInteractiveCohpPlotter::test_plot_colors
  3.06s call     tests/cli/test_cli.py::TestCLI::test_nongz_file_cli
  3.02s call     tests/cli/test_cli.py::TestCLI::test_calc_quality_summary_nacl
  3.00s call     tests/cli/test_cli.py::TestCLI::test_cli_with_poscar_lobster
  2.58s call     tests/plotting/test_plotting.py::TestInteractiveCohpPlotter::test_add_all_relevant_cohps_k3sb
  2.53s call     tests/cohp/test_analyze.py::TestAnalyseCalcQuality::test_calc_quality_summary_with_objs
  2.45s setup    tests/plotting/test_plotting.py::TestInteractiveCohpPlotter::test_add_all_relevant_cohps_nacl_cobi_orb
  ================================================== short test summary info ===================================================
  SKIPPED [1] tests/cli/test_cli.py:706: Only enable this test to regenerate test data
  134 passed, 1 skipped in 279.79s (0:04:39)
  ```