### PR TITLE
change python version from 3.9 to 3.10 in docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -106,7 +106,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ docs = [
     "sphinx_design==0.6.0",
     "myst-nb==1.1.1",
     "sphinx-book-theme==1.1.3",
-    "sphinx-argparse==0.4.0",
+    "sphinx-argparse==0.5.2",
     "sphinx-toolbox==3.7.0",
 ]
 


### PR DESCRIPTION
Fixes #316 failures 

Reason : sphinx-argparse dropped support for python 3.9 since version 0.5.0, thus change in auto doc generation python version is needed

