### PR TITLE
`matplotlib` use non-interactive agg backend

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,6 +58,8 @@ jobs:
     - name: Test with pytest and coverage
       # run this locally to update tests durations
       # pytest --cov=lobsterpy --cov-append --splits 1 --group 1 --durations-path ./tests/test_data/.pytest-split-durations --store-durations
+      env:
+        MPLBACKEND: Agg  # non-interactive backend for matplotlib
       run: |
         micromamba activate lobpy
         pytest --cov=lobsterpy --cov-report term-missing --cov-append --splits 6 --group ${{ matrix.split }} -vv --durations-path ./tests/test_data/.pytest-split-durations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
      "pymatgen>=2024.10.22",
      "numpy<3.0.0",
-     "typing",
 ]
 
 [tool.setuptools.package-data]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,6 +9,7 @@ import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.style
 import numpy as np
@@ -48,7 +49,6 @@ error_test_cases = [
     (["plot", "1", "--orbitalwise", "1s-1s"], IndexError),
 ]
 
-
 class TestCLI:
     @pytest.fixture
     def inject_mocks(self, mocker):  # noqa: PT004
@@ -71,6 +71,10 @@ class TestCLI:
 
     @pytest.mark.parametrize("args", test_cases)
     def test_cli_results(self, args, capsys, inject_mocks, clean_plot):
+
+        # Use non-interactive Agg matplotlib backend to get consistent results across OS
+        mpl.use("Agg")
+
         test = get_parser().parse_args(args)
         run(test)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -9,7 +9,6 @@ import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.style
 import numpy as np

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -72,9 +72,6 @@ class TestCLI:
 
     @pytest.mark.parametrize("args", test_cases)
     def test_cli_results(self, args, capsys, inject_mocks, clean_plot):
-        # Use Ubuntu default backend for consistency across OS
-        mpl.use("agg")
-
         test = get_parser().parse_args(args)
         run(test)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -49,6 +49,7 @@ error_test_cases = [
     (["plot", "1", "--orbitalwise", "1s-1s"], IndexError),
 ]
 
+
 class TestCLI:
     @pytest.fixture
     def inject_mocks(self, mocker):  # noqa: PT004
@@ -71,7 +72,6 @@ class TestCLI:
 
     @pytest.mark.parametrize("args", test_cases)
     def test_cli_results(self, args, capsys, inject_mocks, clean_plot):
-
         # Use non-interactive Agg matplotlib backend to get consistent results across OS
         mpl.use("Agg")
 


### PR DESCRIPTION
Fix a previously added parameter as the original comment is a bit misleading, agg is the [recommended non-interactive backend](https://matplotlib.org/stable/users/explain/figure/backends.html):
> The last, Agg, is a non-interactive backend that can only write to files. It is used on Linux, if Matplotlib cannot connect to either an X display or a Wayland display.