### PR TITLE
Improve calc quality analysis implementation

### DIFF
--- a/tests/cohp/test_describe.py
+++ b/tests/cohp/test_describe.py
@@ -362,28 +362,26 @@ class TestCalcQualityDescribeWarnings:
                 e_range=[-50, 60],
                 dos_comparison=True,
                 bva_comp=False,
+                n_bins=500,
             )
-        messages = []
-        for warning in w:
-            messages.append(str(warning.message))
-        count0 = 0
-        count1 = 0
-        count2 = 0
-        count3 = 0
-        for msg in messages:
-            if "Consider using DOSCAR.LSO.lobster" in msg:
-                count0 += 1
-            if "Minimum energy range requested" in msg:
-                count1 += 1
-            if "Maximum energy range requested" in msg:
-                count2 += 1
-            if "Input DOS files have very few points" in msg:
-                count3 += 1
+        # messages = []
+        actual_warnings = [str(warning.message) for warning in w]
 
-        assert count0 == 1
-        assert count1 == 1
-        assert count2 == 1
-        assert count3 == 1
+        expected_warnings = [
+            "Consider using DOSCAR.LSO.lobster, as non LSO DOS from LOBSTER can have negative DOS values",
+            "The specified number of bins for DOS comparisons (500) exceeds the number of available data points. "
+            "The number of bins will be set to the minimum available data points: 301.",
+            "Minimum energy range requested for DOS comparisons is not available in VASP or LOBSTER calculation. "
+            "Thus, setting min_e to -5 eV",
+            "Maximum energy range requested for DOS comparisons is not available in VASP or LOBSTER calculation. "
+            "Thus, setting max_e to 0 eV",
+            "Input DOS files have very few points in the energy interval and thus comparisons will not be reliable. "
+            "Please rerun the calculations with higher number of DOS points. "
+            "Set NEDOS and COHPSteps tags to >= 2000 in VASP and LOBSTER calculations, respectively.",
+        ]
+
+        for actual, expected in zip(actual_warnings, expected_warnings):
+            assert actual == expected
 
         calc_des = Description.get_calc_quality_description(calc_quality_warnings)
 
@@ -393,7 +391,7 @@ class TestCalcQualityDescribeWarnings:
             "The projected wave function is completely orthonormalized as no bandOverlaps.lobster file is "
             "generated during the LOBSTER run.",
             "The Tanimoto index from DOS comparisons in the energy range between -5, 0 eV for s, p, summed orbitals "
-            "are: 0.4057, 0.2831, 0.2762.",
+            "are: 0.111, 0.0714, 0.0686.",
         ]
 
         with warnings.catch_warnings(record=True) as w2:


### PR DESCRIPTION
Closes #403 

## Changes / Fixes

1. Make the quality analysis also possible with CompleteDos objects as inputs (Should also allow us to bypass the Vasprun object serialization limitation for this  PR https://github.com/materialsproject/crystaltoolkit/pull/459)
2. Dynamically determine the n_bins value based on input DOS data if the user-supplied n_bins is larger than the minimum number of data points available. 